### PR TITLE
Disable pydantic validation in BundleWrapper

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 
 - Nothing changed yet.
 
+- Disable pydantic validation for Bundle in fhirpath.utils.BundleWrapper
 
 0.8.0 (2020-09-25)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,9 +5,7 @@ History
 0.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
-- Disable pydantic validation for Bundle in fhirpath.utils.BundleWrapper
+- Disable pydantic validation for Bundle in fhirpath.utils.BundleWrapper [simonvadee]
 
 0.8.0 (2020-09-25)
 ------------------

--- a/src/fhirpath/engine/es/__init__.py
+++ b/src/fhirpath/engine/es/__init__.py
@@ -272,13 +272,13 @@ class ElasticsearchEngine(Engine):
         return yarl.URL"""
         raise NotImplementedError
 
-    def wrapped_with_bundle(self, result, includes=None):
+    def wrapped_with_bundle(self, result, includes=None, as_json=False):
         """ """
         url = self.current_url()
         if includes is None:
             includes = list()
         wrapper = BundleWrapper(self, result, includes, url, "searchset")
-        return wrapper()
+        return wrapper(as_json=as_json)
 
     def generate_mappings(
         self,

--- a/src/fhirpath/engine/es/mapping.py
+++ b/src/fhirpath/engine/es/mapping.py
@@ -119,7 +119,9 @@ def create_resource_mapping(elements_paths_def, fhir_es_mappings):
 
 
 def fhir_types_mapping(
-    fhir_release: str, reference_analyzer=None, token_normalizer=None,
+    fhir_release: str,
+    reference_analyzer=None,
+    token_normalizer=None,
 ):
     Boolean = {"type": "boolean", "store": False}
     Float = {"type": "float", "store": False}

--- a/src/fhirpath/search.py
+++ b/src/fhirpath/search.py
@@ -658,6 +658,10 @@ class Search(object):
             # Extract IDs from the main query result
             ids = main_query_result.extract_ids()
 
+            # if no IDs were extracted from the main_query_result, skip.
+            if not ids:
+                continue
+
             # Build a Q_ (query) object to join the resource based on reference ids.
             builder = Q_([from_resource_type], self.context.engine)
             terms: List = []

--- a/src/fhirpath/search.py
+++ b/src/fhirpath/search.py
@@ -1437,11 +1437,13 @@ class Search(object):
                 offset = (current_page - 1) * self.result_params["_count"]
         return builder.limit(self.result_params["_count"], offset)
 
-    def response(self, result, includes):
+    def response(self, result, includes, as_json):
         """ """
-        return self.context.engine.wrapped_with_bundle(result, includes)
+        return self.context.engine.wrapped_with_bundle(
+            result, includes=includes, as_json=as_json
+        )
 
-    def __call__(self):
+    def __call__(self, as_json=False):
         """ """
 
         # TODO: chaining
@@ -1467,7 +1469,9 @@ class Search(object):
             # but we should be more explicit about the query context.
             if not self.reverse_chaining_results:
                 return self.response(
-                    EngineResult(EngineResultHeader(total=0), EngineResultBody()), []
+                    EngineResult(EngineResultHeader(total=0), EngineResultBody()),
+                    [],
+                    as_json,
                 )
 
         # MAIN QUERY
@@ -1493,13 +1497,13 @@ class Search(object):
         ]
 
         all_includes = [*include_results, *rev_include_results]
-        return self.response(main_result, all_includes)
+        return self.response(main_result, all_includes, as_json)
 
 
 class AsyncSearch(Search):
     """ """
 
-    async def __call__(self):
+    async def __call__(self, as_json=False):
         """ """
         # TODO: chaining
 
@@ -1523,7 +1527,7 @@ class AsyncSearch(Search):
             # FIXME: we use the result of the last _has query to build the empty bundle,
             # but we should be more explicit about the query context.
             if not self.reverse_chaining_results:
-                return self.response(res, [])
+                return self.response(res, [], as_json)
 
         # MAIN QUERY
         self.main_query = self.build()
@@ -1548,7 +1552,7 @@ class AsyncSearch(Search):
         ]
 
         all_includes = [*include_results, *rev_include_results]
-        return self.response(main_result, all_includes)
+        return self.response(main_result, all_includes, as_json)
 
 
 def fhir_search(context, query_string=None, params=None):

--- a/src/fhirpath/utils.py
+++ b/src/fhirpath/utils.py
@@ -635,13 +635,12 @@ class BundleWrapper:
 
         return link
 
-    def __call__(self):
+    def __call__(self, as_json=False):
         """ """
-        # we use the `construct` method inherited from pydantic.BaseModel because
-        # we don't want to apply pydantic validation when formatting a Bundle.
-        # data should already be valid at this point since it already been indexed
-        # in elasticsearch
-        return self.bundle_model.construct(None, **self.data)
+        if as_json:
+            # if as_json is True, return the bundle as python dict instead of building a pydantic.BaseModel
+            return self.data
+        return self.bundle_model.parse_obj(self.data)
 
     def json(self):
         """ """

--- a/src/fhirpath/utils.py
+++ b/src/fhirpath/utils.py
@@ -637,7 +637,11 @@ class BundleWrapper:
 
     def __call__(self):
         """ """
-        return self.bundle_model.parse_obj(self.data)
+        # we use the `construct` method inherited from pydantic.BaseModel because
+        # we don't want to apply pydantic validation when formatting a Bundle.
+        # data should already be valid at this point since it already been indexed
+        # in elasticsearch
+        return self.bundle_model.construct(None, **self.data)
 
     def json(self):
         """ """

--- a/src/fhirpath/utils.py
+++ b/src/fhirpath/utils.py
@@ -638,7 +638,8 @@ class BundleWrapper:
     def __call__(self, as_json=False):
         """ """
         if as_json:
-            # if as_json is True, return the bundle as python dict instead of building a pydantic.BaseModel
+            # if as_json is True, return the bundle as python dict
+            # instead of building a pydantic.BaseModel
             return self.data
         return self.bundle_model.parse_obj(self.data)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -439,6 +439,25 @@ def test_search_result(es_data, engine):
     assert bundle.total == 1
 
 
+def test_search_result_as_json(es_data, engine):
+    """ """
+    search_context = SearchContext(engine, "Organization")
+    params = (
+        ("active", "true"),
+        ("_lastUpdated", "2010-05-28T05:35:56+00:00"),
+        ("_profile", "http://hl7.org/fhir/Organization"),
+        ("identifier", "urn:oid:2.16.528.1|91654"),
+        ("type", "http://hl7.org/fhir/organization-type|prov"),
+        ("address-postalcode", "9100 AA"),
+        ("address", "Den Burg"),
+    )
+    fhir_search = Search(search_context, params=params)
+
+    bundle = fhir_search(as_json=True)
+    assert bundle["total"] == 1
+    assert isinstance(bundle["entry"][0], dict)
+
+
 def test_search_missing_modifier(es_data, engine):
     """ """
     search_context = SearchContext(engine, "Organization")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -821,6 +821,14 @@ def test_search_revinclude(es_data, engine):
     assert isinstance(bundle.entry[0].resource, Patient)
     assert isinstance(bundle.entry[1].resource, Observation)
 
+    # no results
+    search_context = SearchContext(engine, "Location")
+    params = (("_revinclude", "Observation:subject"),)
+    fhir_search = Search(search_context, params=params)
+    bundle = fhir_search()
+    assert bundle.total == 0
+    assert len(bundle.entry) == 0
+
     # double _revinclude
     search_context = SearchContext(engine, "Patient")
     params = (


### PR DESCRIPTION
We had huge performance issues when validating large bundles in the BundleWrapper.
When the data is indexed is Ealsticsearch (or elsewhere), it should already be valid anyway, so there is no point in re-validating the data afterwards.