### PR TITLE
Only apply search prefix on affected types

### DIFF
--- a/src/fhirpath/fhirspec/__init__.py
+++ b/src/fhirpath/fhirspec/__init__.py
@@ -11,6 +11,7 @@ from fhirpath.enums import FHIR_VERSION
 from fhirpath.storage import FHIR_RESOURCE_SPEC_STORAGE, SEARCH_PARAMETERS_STORAGE
 
 from .spec import (  # noqa: F401
+    search_param_prefixes,
     FHIRSearchSpec,
     ResourceSearchParameterDefinition,
     SearchParameter,

--- a/src/fhirpath/fhirspec/spec.py
+++ b/src/fhirpath/fhirspec/spec.py
@@ -10,7 +10,7 @@ import pathlib
 import re
 from collections import defaultdict
 from copy import copy
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Set
 
 from fhirpath.enums import FHIR_VERSION
 from fhirpath.interfaces import IStorage
@@ -22,6 +22,20 @@ logger = logging.getLogger("fhirpath.fhrspec")
 # allow to skip some profiles by matching against their url (used while WiP)
 skip_because_unsupported = [r"SimpleQuantity"]
 HTTP_URL = re.compile(r"^https?://", re.IGNORECASE)
+
+
+types_with_prefix: Set[str] = {"number", "date", "quantity"}
+search_param_prefixes: Set[str] = {
+    "eq",
+    "ne",
+    "gt",
+    "lt",
+    "ge",
+    "le",
+    "sa",
+    "eb",
+    "ap",
+}
 
 
 class FHIRSearchSpec(object):
@@ -229,6 +243,9 @@ class SearchParameter(object):
     def clone(self):
         """ """
         return self.__copy__()
+
+    def support_prefix(self):
+        return self.type in types_with_prefix
 
     def __copy__(self):
         """ """

--- a/src/fhirpath/search.py
+++ b/src/fhirpath/search.py
@@ -18,6 +18,7 @@ from fhirpath.enums import (
 from fhirpath.exceptions import ValidationError
 from fhirpath.fhirspec import (
     FHIRSearchSpecFactory,
+    search_param_prefixes,
     ResourceSearchParameterDefinition,
     SearchParameter,
 )
@@ -162,7 +163,7 @@ class SearchContext(object):
                 raw_value = raw_value[0]
 
             values: List = list()
-            self.normalize_param_value(raw_value, values)
+            self.normalize_param_value(raw_value, sp, values)
 
             if len(values) == 1:
                 param_value_ = values[0]
@@ -174,12 +175,14 @@ class SearchContext(object):
             normalized_params.append((_path, param_value_, modifier_))
         return normalized_params
 
-    def normalize_param_value(self, raw_value: Union[List, str], container):
+    def normalize_param_value(
+        self, raw_value: Union[List, str], search_param: SearchParameter, container
+    ):
         """ """
         if isinstance(raw_value, list):
             bucket: List[str] = list()
             for rv in raw_value:
-                self.normalize_param_value(rv, bucket)
+                self.normalize_param_value(rv, search_param, bucket)
             if len(bucket) == 1:
                 container.append(bucket[0])
             else:
@@ -201,8 +204,8 @@ class SearchContext(object):
                 else:
                     val_ = val
 
-                for prefix in value_prefixes:
-                    if val_.startswith(prefix):
+                for prefix in search_param_prefixes:
+                    if val_.startswith(prefix) and search_param.support_prefix():
                         comparison_operator = prefix
                         val_ = val_[2:]
                         break
@@ -250,7 +253,7 @@ class SearchContext(object):
             value_parts[0],
         ]
         part1_param_value = list()
-        self.normalize_param_value(part1[1], part1_param_value)
+        self.normalize_param_value(part1[1], param_def, part1_param_value)
         if len(part1_param_value) == 1:
             part1_param_value = part1_param_value[0]
         composite_bucket.append(
@@ -264,7 +267,7 @@ class SearchContext(object):
             ]
             part2.append(part_)
         part2_param_value = list()
-        self.normalize_param_value(part2[0][1], part2_param_value)
+        self.normalize_param_value(part2[0][1], param_def, part2_param_value)
 
         if len(part2_param_value) == 1:
             part2_param_value = part2_param_value[0]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -158,12 +158,42 @@ def test_parameter_normalization_with_space_as(engine):
     """ """
     context = SearchContext(engine, "MedicationRequest")
 
-    path_, value_pack, modifier = context.normalize_param(
+    path_, value_pack, _ = context.normalize_param(
         "code", ["http://acme.org/conditions/codes|ha125"]
     )[0]
     # single valued
     assert isinstance(value_pack, tuple)
     assert path_.path == "MedicationRequest.medicationCodeableConcept"
+
+
+def test_parameter_normalization_prefix(engine):
+    """ """
+    # number
+    context = SearchContext(engine, "MolecularSequence")
+    _, value_pack, _ = context.normalize_param("variant-end", ["gt1"])[0]
+    assert value_pack == ("gt", "1")
+
+    # quantity
+    context = SearchContext(engine, "Substance")
+    _, value_pack, _ = context.normalize_param("quantity", ["ne1"])[0]
+    assert value_pack == ("ne", "1")
+
+    # date
+    context = SearchContext(engine, "Patient")
+    _, value_pack, _ = context.normalize_param("death-date", ["lt1980"])[0]
+    assert value_pack == ("lt", "1980")
+
+    # string
+    _, value_pack, _ = context.normalize_param("name", ["leslie"])[0]
+    assert value_pack == ("eq", "leslie")
+
+    # token
+    _, value_pack, _ = context.normalize_param("language", ["nepalese"])[0]
+    assert value_pack == ("eq", "nepalese")
+
+    # reference
+    _, value_pack, _ = context.normalize_param("organization", ["necker"])[0]
+    assert value_pack == ("eq", "necker")
 
 
 def test_create_term(engine):


### PR DESCRIPTION
This fixes an inconvenient issue:
The search: `?Patient?name=leslie` should match patients whose name matches `leslie` and not apply the `le` (less or equal) prefix to the string `slie`.