### PR TITLE
Fix tests for search prefix on strings

### DIFF
--- a/src/fhirpath/fhirspec/__init__.py
+++ b/src/fhirpath/fhirspec/__init__.py
@@ -11,11 +11,11 @@ from fhirpath.enums import FHIR_VERSION
 from fhirpath.storage import FHIR_RESOURCE_SPEC_STORAGE, SEARCH_PARAMETERS_STORAGE
 
 from .spec import (  # noqa: F401
-    search_param_prefixes,
     FHIRSearchSpec,
     ResourceSearchParameterDefinition,
     SearchParameter,
     logger,
+    search_param_prefixes,
 )
 
 __author__ = "Md Nazrul Islam<email2nazrul@gmail.com>"

--- a/src/fhirpath/search.py
+++ b/src/fhirpath/search.py
@@ -18,9 +18,9 @@ from fhirpath.enums import (
 from fhirpath.exceptions import ValidationError
 from fhirpath.fhirspec import (
     FHIRSearchSpecFactory,
-    search_param_prefixes,
     ResourceSearchParameterDefinition,
     SearchParameter,
+    search_param_prefixes,
 )
 from fhirpath.fql import (
     G_,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -553,11 +553,6 @@ def test_search_result_with_below_modifier(es_data, engine):
     bundle = fhir_search()
     assert bundle.total == 1
 
-    params = (("given", "saEel"),)
-    fhir_search = Search(search_context, params=params)
-    bundle = fhir_search()
-    assert bundle.total == 1
-
     params = (("given:below", "Eel,Eve"),)
     fhir_search = Search(search_context, params=params)
     bundle = fhir_search()
@@ -574,11 +569,6 @@ def test_search_result_with_above_modifier(es_data, engine):
     # little bit complex
     search_context = SearchContext(engine, "Patient")
     params = (("identifier:above", "|0002"),)
-    fhir_search = Search(search_context, params=params)
-    bundle = fhir_search()
-    assert bundle.total == 1
-
-    params = (("given", "ebctor"),)
     fhir_search = Search(search_context, params=params)
     bundle = fhir_search()
     assert bundle.total == 1
@@ -1034,17 +1024,8 @@ def test_search_fhirpath_reference_analyzer(es_data, engine):
     bundle = fhir_search()
     assert bundle.total == 1
 
-    params = (("subject", "saPatient"),)
-    fhir_search = Search(search_context, params=params)
-    bundle = fhir_search()
-    assert bundle.total == 1
-
-    params = (("subject:not", "saPatient"),)
-    fhir_search = Search(search_context, params=params)
-    bundle = fhir_search()
-    assert bundle.total == 0
-
-    params = (("subject:not", "saDevice"),)
+    # search by ID as suffix
+    params = (("subject:above", "19c5245f-89a8-49f8-b244-666b32adb92e"),)
     fhir_search = Search(search_context, params=params)
     bundle = fhir_search()
     assert bundle.total == 1


### PR DESCRIPTION
Remove tests using search prefixes on strings (not conform to the FHIR search specification).
Quoting the doc:
```
For the ordered parameter types of number, date, and quantity, a prefix to the parameter value may be used to control the nature of the matching
```

This PR is a replacement for #18 (which should not be merged).