### PR TITLE
Ignore empty search parameters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 0.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Ignore empty search params #21 [simonvadee]
 
 
 0.8.1 (2020-10-05)

--- a/src/fhirpath/search.py
+++ b/src/fhirpath/search.py
@@ -165,6 +165,9 @@ class SearchContext(object):
             values: List = list()
             self.normalize_param_value(raw_value, sp, values)
 
+            if len(values) == 0:
+                # empty parameters are not considered an error, they should be ignored
+                continue
             if len(values) == 1:
                 param_value_ = values[0]
             else:
@@ -179,7 +182,10 @@ class SearchContext(object):
         self, raw_value: Union[List, str], search_param: SearchParameter, container
     ):
         """ """
-        if isinstance(raw_value, list):
+        if not raw_value:
+            return
+
+        elif isinstance(raw_value, list):
             bucket: List[str] = list()
             for rv in raw_value:
                 self.normalize_param_value(rv, search_param, bucket)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -166,6 +166,13 @@ def test_parameter_normalization_with_space_as(engine):
     assert path_.path == "MedicationRequest.medicationCodeableConcept"
 
 
+def test_parameter_normalization_empty_value(engine):
+    context = SearchContext(engine, "MedicationRequest")
+    # normalize a param with an empty value: it should be ignored
+    params = context.normalize_param("code", [""])
+    assert len(params) == 0
+
+
 def test_parameter_normalization_prefix(engine):
     """ """
     # number


### PR DESCRIPTION
For instance the query `Patient?_id=` should return all patients since the empty `_id=` param is ignored.
Quoting the FHIR spec:
```
 Note: Empty parameters are not an error - they are just ignored by the server. 
```