### PR TITLE
Handle :identifier modifier for reference search parameters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 0.8.2 (unreleased)
 ------------------
 
+- Handle ``:identifier`` modifier for reference search parameters [simonvadee]
+
 - ``Dict`` response option has bee added in ``fhirpath.search.fhir_search`` [nazrulworld]
 
 - Ignore empty search params #21 [simonvadee]

--- a/src/fhirpath/search.py
+++ b/src/fhirpath/search.py
@@ -95,7 +95,8 @@ class SearchContext(object):
         self.definitions = self.get_parameters_definition(self.engine.fhir_release)
 
     def get_parameters_definition(
-        self, fhir_release: FHIR_VERSION,
+        self,
+        fhir_release: FHIR_VERSION,
     ) -> List[ResourceSearchParameterDefinition]:
         """ """
         fhir_release = FHIR_VERSION.normalize(fhir_release)
@@ -735,8 +736,12 @@ class Search(object):
             # we need normalization
             klass_name = path_.context.type_class.fhir_type_name()
             if klass_name == "Reference":
-                path_ = path_ / "reference"
-                term_factory = self.create_term
+                if modifier == "identifier":
+                    path_ = path_ / "identifier"
+                    term_factory = self.create_identifier_term
+                else:
+                    path_ = path_ / "reference"
+                    term_factory = self.create_term
             elif klass_name == "Identifier":
                 term_factory = self.create_identifier_term
             elif klass_name in ("Quantity", "Duration"):

--- a/tests/_static/FHIR/Observation.json
+++ b/tests/_static/FHIR/Observation.json
@@ -20,7 +20,8 @@
     },
     "subject": {
         "reference": "Patient/19c5245f-89a8-49f8-b244-666b32adb92e",
-        "display": "P. van de Heuvel"
+        "display": "P. van de Heuvel",
+        "identifier": { "system": "CPR", "value": "240365-0002" }
     },
     "effectivePeriod": {
         "start": "2013-04-05T10:30:10+01:00",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -638,6 +638,66 @@ def test_search_result_with_exact_modifier(es_data, engine):
     assert bundle.total == 0
 
 
+def test_search_identifier_modifier(es_data, engine):
+    search_context = SearchContext(engine, "Observation")
+
+    params = (("subject:identifier", "240365-0002"),)
+    bundle = Search(search_context, params=params)()
+    assert bundle.total == 1
+
+    params = (("subject:identifier", "123465789"),)
+    bundle = Search(search_context, params=params)()
+    assert bundle.total == 0
+
+    # [param-ref]:identifier=[system]|[value]: the value of [code] matches an
+    # reference.identifier.value, and the value of [system] matches the system
+    # property of the Identifier
+    params = (
+        (
+            "subject:identifier",
+            "CPR|240365-0002",
+        ),
+    )
+    bundle = Search(search_context, params=params)()
+    assert bundle.total == 1
+
+    params = (
+        (
+            "subject:identifier",
+            "CPR|123456789",
+        ),
+    )
+    bundle = Search(search_context, params=params)()
+    assert bundle.total == 0
+
+    # TODO: not working yet, when omitting the system, the search is applied only on the value
+    # (it should also filter by empty system)
+    # [param-ref]:identifier=|[code]: the value of [code] matches a reference.identifier.value,
+    # and the Identifier has no system property
+    params = (("subject:identifier", "|240365-0002"),)
+    bundle = Search(search_context, params=params)()
+    assert bundle.total == 1
+
+    params = (("subject:identifier", "|123456789"),)
+    bundle = Search(search_context, params=params)()
+    assert bundle.total == 0
+
+    # [param-ref]:identifier=[system]|: any element where the value of [system] matches the
+    # system property of the Identifier
+    params = (
+        (
+            "subject:identifier",
+            "CPR|",
+        ),
+    )
+    bundle = Search(search_context, params=params)()
+    assert bundle.total == 1
+
+    params = (("subject:identifier", "other|"),)
+    bundle = Search(search_context, params=params)()
+    assert bundle.total == 0
+
+
 def test_issue9_multiple_negative_terms_not_working(es_data, engine):
     """https://github.com/nazrulworld/fhirpath/issues/9"""
     search_context = SearchContext(engine, "Task")


### PR DESCRIPTION
Handle queries like `Observation?subject:identifier=CPR|240365-0002`

cf FHIR doc: https://www.hl7.org/fhir/search.html#reference