### PR TITLE
Split selects and elements, handle summaries 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,9 @@ History
 0.9.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added support for `_summary=text|data|count|true|false`. [arkhn]
+
+- `QueryResult.count()` now returns a fhir.resources.bundle.Bundle instead of an integer. The previous behaviour of `.count()` is still implemented by the `.__len__()` method. [arkhn]
 
 
 0.9.1 (2020-10-24)

--- a/src/fhirpath/dialects/elasticsearch.py
+++ b/src/fhirpath/dialects/elasticsearch.py
@@ -316,10 +316,7 @@ class ElasticSearchDialect(DialectBase):
             # "Resource" as path.context.resource_type
             # Use "*" as root_replacer to match any resource across the ES mapping.
             return self.compile_for_single_resource_type(
-                query,
-                resource_type="Resource",
-                mapping=None,
-                root_replacer="*",
+                query, resource_type="Resource", mapping=None, root_replacer="*",
             )
         elif len(query_fragments) > 1:
             return {
@@ -783,7 +780,9 @@ class ElasticSearchDialect(DialectBase):
                 includes.append(root_replacer)
         elif len(query.get_element()) > 0:
             # always include the resourceType in the ES response
-            includes.append(f"{root_replacer+'.' if root_replacer else ''}resourceType")
+            includes.append(
+                f"{root_replacer}.resourceType" if root_replacer else "resourceType"
+            )
             for path_el in query.get_element():
                 includes.append(replace(path_el))
 

--- a/src/fhirpath/dialects/elasticsearch.py
+++ b/src/fhirpath/dialects/elasticsearch.py
@@ -761,7 +761,7 @@ class ElasticSearchDialect(DialectBase):
                 because here permission is not checking while getting full object.
         """
 
-        if len(query.get_select()) == 0:
+        if len(query.get_element()) == 0:
             # No select no source!
             body_structure["_source"] = False
             return
@@ -776,13 +776,15 @@ class ElasticSearchDialect(DialectBase):
                 return root_replacer
 
         includes = list()
-        if len(query.get_select()) == 1 and query.get_select()[0].star:
+        if len(query.get_element()) == 1 and query.get_element()[0].star:
             if root_replacer is None:
                 includes.append(query.get_from()[0][0])
             else:
                 includes.append(root_replacer)
-        elif len(query.get_select()) > 0:
-            for path_el in query.get_select():
+        elif len(query.get_element()) > 0:
+            # always include the resourceType in the ES response
+            includes.append(f"{root_replacer+'.' if root_replacer else ''}resourceType")
+            for path_el in query.get_element():
                 includes.append(replace(path_el))
 
         if len(includes) > 0:

--- a/src/fhirpath/dialects/elasticsearch.py
+++ b/src/fhirpath/dialects/elasticsearch.py
@@ -316,7 +316,10 @@ class ElasticSearchDialect(DialectBase):
             # "Resource" as path.context.resource_type
             # Use "*" as root_replacer to match any resource across the ES mapping.
             return self.compile_for_single_resource_type(
-                query, resource_type="Resource", mapping=None, root_replacer="*",
+                query,
+                resource_type="Resource",
+                mapping=None,
+                root_replacer="*",
             )
         elif len(query_fragments) > 1:
             return {

--- a/src/fhirpath/engine/base.py
+++ b/src/fhirpath/engine/base.py
@@ -118,7 +118,9 @@ class EngineResult(object):
     body: EngineResultBody
 
     def __init__(
-        self, header: EngineResultHeader, body: EngineResultBody,
+        self,
+        header: EngineResultHeader,
+        body: EngineResultBody,
     ):
         """ """
         self.header = header

--- a/src/fhirpath/engine/base.py
+++ b/src/fhirpath/engine/base.py
@@ -118,9 +118,7 @@ class EngineResult(object):
     body: EngineResultBody
 
     def __init__(
-        self,
-        header: EngineResultHeader,
-        body: EngineResultBody,
+        self, header: EngineResultHeader, body: EngineResultBody,
     ):
         """ """
         self.header = header
@@ -218,6 +216,7 @@ class EngineResult(object):
 
         return ids
 
+
 def navigate_indexed_path(source, path_):
     """ """
     parts = path_.split("[")
@@ -232,13 +231,12 @@ def navigate_indexed_path(source, path_):
     except IndexError:
         return None
 
+
 def _traverse_for_value(source, path_):
     """Looks path_ is innocent string key, but may content expression, function."""
     if isinstance(source, dict):
         # xxx: validate path, not blindly sending None
-        if CONTAINS_INDEX_OR_FUNCTION.search(path_) and CONTAINS_FUNCTION.match(
-            path_
-        ):
+        if CONTAINS_INDEX_OR_FUNCTION.search(path_) and CONTAINS_FUNCTION.match(path_):
             raise ValidationError(
                 f"Invalid path {path_} has been supllied!"
                 "Path cannot contain function if source type is dict"

--- a/src/fhirpath/engine/base.py
+++ b/src/fhirpath/engine/base.py
@@ -2,6 +2,7 @@
 import time
 from abc import ABC
 from collections import defaultdict, deque
+import re
 from typing import Dict, List
 
 from zope.interface import implementer
@@ -20,6 +21,10 @@ from fhirpath.interfaces.engine import (
 from fhirpath.thirdparty import Proxy
 
 __author__ = "Md Nazrul Islam <email2nazrul@gmail.com>"
+
+CONTAINS_INDEX_OR_FUNCTION = re.compile(r"[a-z09_]+(\[[0-9]+\])|(\([0-9]*\))$", re.I)
+CONTAINS_INDEX = re.compile(r"[a-z09_]+\[[0-9]+\]$", re.I)
+CONTAINS_FUNCTION = re.compile(r"[a-z09_]+\([0-9]*\)$", re.I)
 
 
 @implementer(IEngine)
@@ -121,6 +126,23 @@ class EngineResult(object):
         self.header = header
         self.body = body
 
+    def filter(self, selects):
+        if len(selects) > 0:
+            new_body = EngineResultBody()
+            for row in self.body:
+                new_row = EngineResultRow()
+                source = row[0]
+                for fullpath in selects:
+                    for path_ in fullpath.split("."):
+                        source = _traverse_for_value(source, path_)
+                        if source is None:
+                            break
+                    new_row.append(source)
+                new_body.append(new_row)
+            self.body = new_body
+
+        return self
+
     def extract_ids(self) -> Dict[str, List[str]]:
         ids: Dict = defaultdict(list)
         for row in self.body:
@@ -195,3 +217,84 @@ class EngineResult(object):
                 append_ref(ref_attribute)
 
         return ids
+
+def navigate_indexed_path(source, path_):
+    """ """
+    parts = path_.split("[")
+    p_ = parts[0]
+    index = int(parts[1][:-1])
+    value = source.get(p_, None)
+    if value is None:
+        return value
+
+    try:
+        return value[index]
+    except IndexError:
+        return None
+
+def _traverse_for_value(source, path_):
+    """Looks path_ is innocent string key, but may content expression, function."""
+    if isinstance(source, dict):
+        # xxx: validate path, not blindly sending None
+        if CONTAINS_INDEX_OR_FUNCTION.search(path_) and CONTAINS_FUNCTION.match(
+            path_
+        ):
+            raise ValidationError(
+                f"Invalid path {path_} has been supllied!"
+                "Path cannot contain function if source type is dict"
+            )
+        if CONTAINS_INDEX.match(path_):
+            return navigate_indexed_path(source, path_)
+        if path_ == "*":
+            # TODO check if we can have other keys than resource
+            return source[list(source.keys())[0]]
+
+        return source.get(path_, None)
+
+    elif isinstance(source, list):
+        if not CONTAINS_FUNCTION.match(path_):
+            raise ValidationError(
+                f"Invalid path {path_} has been supllied!"
+                "Path should contain function if source type is list"
+            )
+        parts = path_.split("(")
+        func_name = parts[0]
+        index = None
+        if len(parts[1]) > 1:
+            index = int(parts[1][:-1])
+        if func_name == "count":
+            return len(source)
+        elif func_name == "first":
+            return source[0]
+        elif func_name == "last":
+            return source[-1]
+        elif func_name == "Skip":
+            new_order = list()
+            for idx, no in enumerate(source):
+                if idx == index:
+                    continue
+                new_order.append(no)
+            return new_order
+        elif func_name == "Take":
+            try:
+                return source[index]
+            except IndexError:
+                return None
+        else:
+            raise NotImplementedError
+    elif isinstance(source, (bytes, str)):
+        if not CONTAINS_FUNCTION.match(path_):
+            raise ValidationError(
+                f"Invalid path {path_} has been supplied!"
+                "Path should contain function if source type is list"
+            )
+        parts = path_.split("(")
+        func_name = parts[0]
+        index = len(parts[1]) > 1 and int(parts[1][:-1]) or None
+        if func_name == "count":
+            return len(source)
+        else:
+            raise NotImplementedError
+
+    else:
+        raise NotImplementedError

--- a/src/fhirpath/engine/base.py
+++ b/src/fhirpath/engine/base.py
@@ -17,7 +17,6 @@ from fhirpath.interfaces.engine import (
     IEngineResultHeader,
     IEngineResultRow,
 )
-from fhirpath.query import Query
 from fhirpath.thirdparty import Proxy
 
 __author__ = "Md Nazrul Islam <email2nazrul@gmail.com>"
@@ -42,10 +41,6 @@ class Engine(ABC):
         self.create_connection(conn_factory)
 
         self.create_dialect(dialect_factory)
-
-    def create_query(self):
-        """ """
-        return Query.with_engine(self.__proxy__())
 
     def create_connection(self, factory):
         """ """
@@ -82,7 +77,7 @@ class EngineResultHeader(object):
     total = None
     raw_query = None
     generated_on = None
-    selects = None
+    elements = None
 
     def __init__(self, total, raw_query=None):
         """ """

--- a/src/fhirpath/engine/base.py
+++ b/src/fhirpath/engine/base.py
@@ -1,5 +1,4 @@
 # _*_ coding: utf-8 _*_
-import re
 import time
 from abc import ABC
 from collections import defaultdict, deque
@@ -21,10 +20,6 @@ from fhirpath.interfaces.engine import (
 from fhirpath.thirdparty import Proxy
 
 __author__ = "Md Nazrul Islam <email2nazrul@gmail.com>"
-
-CONTAINS_INDEX_OR_FUNCTION = re.compile(r"[a-z09_]+(\[[0-9]+\])|(\([0-9]*\))$", re.I)
-CONTAINS_INDEX = re.compile(r"[a-z09_]+\[[0-9]+\]$", re.I)
-CONTAINS_FUNCTION = re.compile(r"[a-z09_]+\([0-9]*\)$", re.I)
 
 
 @implementer(IEngine)
@@ -200,18 +195,3 @@ class EngineResult(object):
                 append_ref(ref_attribute)
 
         return ids
-
-
-def navigate_indexed_path(source, path_):
-    """ """
-    parts = path_.split("[")
-    p_ = parts[0]
-    index = int(parts[1][:-1])
-    value = source.get(p_, None)
-    if value is None:
-        return value
-
-    try:
-        return value[index]
-    except IndexError:
-        return None

--- a/src/fhirpath/engine/base.py
+++ b/src/fhirpath/engine/base.py
@@ -1,8 +1,8 @@
 # _*_ coding: utf-8 _*_
+import re
 import time
 from abc import ABC
 from collections import defaultdict, deque
-import re
 from typing import Dict, List
 
 from zope.interface import implementer

--- a/src/fhirpath/engine/es/__init__.py
+++ b/src/fhirpath/engine/es/__init__.py
@@ -1,5 +1,4 @@
 # _*_ coding: utf-8 _*_
-import re
 from collections import defaultdict
 from typing import Dict, List, Optional
 
@@ -19,13 +18,11 @@ from fhirpath.engine.es.mapping import (
     fhir_types_mapping,
 )
 from fhirpath.enums import EngineQueryType
-from fhirpath.exceptions import ValidationError
 from fhirpath.fhirspec import FhirSpecFactory
 from fhirpath.interfaces import IElasticsearchEngine
 from fhirpath.utils import BundleWrapper
 
 __author__ = "Md Nazrul Islam<email2nazrul@gmail.com>"
-
 
 
 @implementer(IElasticsearchEngine)
@@ -191,9 +188,7 @@ class ElasticsearchEngine(Engine):
         return wrapper(as_json=as_json)
 
     def generate_mappings(
-        self,
-        reference_analyzer: str = None,
-        token_normalizer: str = None,
+        self, reference_analyzer: str = None, token_normalizer: str = None,
     ):
         """
         You may use this function to build the ES mapping.

--- a/src/fhirpath/engine/es/__init__.py
+++ b/src/fhirpath/engine/es/__init__.py
@@ -188,7 +188,9 @@ class ElasticsearchEngine(Engine):
         return wrapper(as_json=as_json)
 
     def generate_mappings(
-        self, reference_analyzer: str = None, token_normalizer: str = None,
+        self,
+        reference_analyzer: str = None,
+        token_normalizer: str = None,
     ):
         """
         You may use this function to build the ES mapping.

--- a/src/fhirpath/engine/es/__init__.py
+++ b/src/fhirpath/engine/es/__init__.py
@@ -24,26 +24,8 @@ from fhirpath.fhirspec import FhirSpecFactory
 from fhirpath.interfaces import IElasticsearchEngine
 from fhirpath.utils import BundleWrapper
 
-CONTAINS_INDEX_OR_FUNCTION = re.compile(r"[a-z09_]+(\[[0-9]+\])|(\([0-9]*\))$", re.I)
-CONTAINS_INDEX = re.compile(r"[a-z09_]+\[[0-9]+\]$", re.I)
-CONTAINS_FUNCTION = re.compile(r"[a-z09_]+\([0-9]*\)$", re.I)
-
 __author__ = "Md Nazrul Islam<email2nazrul@gmail.com>"
 
-
-def navigate_indexed_path(source, path_):
-    """ """
-    parts = path_.split("[")
-    p_ = parts[0]
-    index = int(parts[1][:-1])
-    value = source.get(p_, None)
-    if value is None:
-        return value
-
-    try:
-        return value[index]
-    except IndexError:
-        return None
 
 
 @implementer(IElasticsearchEngine)
@@ -63,109 +45,42 @@ class ElasticsearchEngine(Engine):
         # Process additional meta
         result.header.raw_query = self.connection.finalize_search_params(compiled)
 
-        source_filters = self._get_source_filters(query.get_select())
-        if len(source_filters) == 0:
+        element_filters = self._get_element_filters(query.get_element())
+        if len(element_filters) == 0:
             return
 
-        selects = list()
+        elements = list()
         for froms in query.get_from():
             resource_type = froms[0]
             field_index_name = self.calculate_field_index_name(resource_type)
-            for path_ in source_filters:
+            for path_ in element_filters:
                 if not path_.startswith(field_index_name):
-                    selects.append(path_)
+                    elements.append(path_)
                     continue
                 parts = path_.split(".")
                 if len(parts) == 1:
-                    selects.append(resource_type)
+                    elements.append(resource_type)
                 else:
-                    selects.append(".".join([resource_type] + parts[1:]))
+                    elements.append(".".join([resource_type] + parts[1:]))
 
-        result.header.selects = selects
+        result.header.elements = elements
 
-    def _get_source_filters(self, selects):
+    def _get_element_filters(self, elements):
         """ """
-        source_filters = []
-        for el_path in selects:
+        element_filters = []
+        for el_path in elements:
             if el_path.star:
-                source_filters.append("*")
+                element_filters.append("*")
                 break
             if el_path.non_fhir is True:
                 # No replacer for Non Fhir Path
-                source_filters.append(el_path.path)
+                element_filters.append(el_path.path)
                 continue
             parts = el_path._raw.split(".")
-            source_filters.append(
+            element_filters.append(
                 ".".join([self.calculate_field_index_name(parts[0]), *parts[1:]])
             )
-        return source_filters
-
-    def _traverse_for_value(self, source, path_):
-        """Looks path_ is innocent string key, but may content expression, function."""
-        if isinstance(source, dict):
-            # xxx: validate path, not blindly sending None
-            if CONTAINS_INDEX_OR_FUNCTION.search(path_) and CONTAINS_FUNCTION.match(
-                path_
-            ):
-                raise ValidationError(
-                    f"Invalid path {path_} has been supllied!"
-                    "Path cannot contain function if source type is dict"
-                )
-            if CONTAINS_INDEX.match(path_):
-                return navigate_indexed_path(source, path_)
-            if path_ == "*":
-                # TODO check if we can have other keys than resource
-                return source[list(source.keys())[0]]
-
-            return source.get(path_, None)
-
-        elif isinstance(source, list):
-            if not CONTAINS_FUNCTION.match(path_):
-                raise ValidationError(
-                    f"Invalid path {path_} has been supllied!"
-                    "Path should contain function if source type is list"
-                )
-            parts = path_.split("(")
-            func_name = parts[0]
-            index = None
-            if len(parts[1]) > 1:
-                index = int(parts[1][:-1])
-            if func_name == "count":
-                return len(source)
-            elif func_name == "first":
-                return source[0]
-            elif func_name == "last":
-                return source[-1]
-            elif func_name == "Skip":
-                new_order = list()
-                for idx, no in enumerate(source):
-                    if idx == index:
-                        continue
-                    new_order.append(no)
-                return new_order
-            elif func_name == "Take":
-                try:
-                    return source[index]
-                except IndexError:
-                    return None
-            else:
-                raise NotImplementedError
-        elif isinstance(source, (bytes, str)):
-            if not CONTAINS_FUNCTION.match(path_):
-                raise ValidationError(
-                    f"Invalid path {path_} has been supplied!"
-                    "Path should contain function if source type is list"
-                )
-            parts = path_.split("(")
-            func_name = parts[0]
-            index = len(parts[1]) > 1 and int(parts[1][:-1]) or None
-            if func_name == "count":
-                return len(source)
-            else:
-                raise NotImplementedError
-
-        else:
-            raise NotImplementedError
+        return element_filters
 
     def _execute(self, query, unrestricted, query_type):
         """ """
@@ -191,9 +106,9 @@ class ElasticsearchEngine(Engine):
     def execute(self, query, unrestricted=False, query_type=EngineQueryType.DML):
         """ """
         raw_result, compiled = self._execute(query, unrestricted, query_type)
-        selects = query.get_select()
+        elements = query.get_element()
         # xxx: process result
-        result = self.process_raw_result(raw_result, selects, query_type)
+        result = self.process_raw_result(raw_result, elements, query_type)
 
         # Process additional meta
         self._add_result_headers(query, result, compiled)
@@ -206,44 +121,39 @@ class ElasticsearchEngine(Engine):
     def calculate_field_index_name(self, resource_type):
         raise NotImplementedError
 
-    def extract_hits(self, source_filters, hits, container, doc_type="_doc"):
+    def extract_hits(self, element_filters, hits, container, doc_type="_doc"):
         """ """
         for res in hits:
             if res["_type"] != doc_type:
                 continue
             row = EngineResultRow()
-            for fullpath in source_filters:
-                source = res["_source"]
-                for path_ in fullpath.split("."):
-                    source = self._traverse_for_value(source, path_)
-                    if source is None:
-                        break
-                row.append(source)
+            for resource_data in res["_source"].values():
+                row.append(resource_data)
 
             container.add(row)
 
-    def process_raw_result(self, rawresult, selects, query_type):
+    def process_raw_result(self, rawresult, elements, query_type):
         """ """
         if query_type == EngineQueryType.COUNT:
             total = rawresult["count"]
-            source_filters = []
+            element_filters = []
         # let´s make some compabilities
         elif isinstance(rawresult["hits"]["total"], dict):
             total = rawresult["hits"]["total"]["value"]
-            source_filters = self._get_source_filters(selects)
+            element_filters = self._get_element_filters(elements)
         else:
             total = rawresult["hits"]["total"]
-            source_filters = self._get_source_filters(selects)
+            element_filters = self._get_element_filters(elements)
 
         result = EngineResult(
             header=EngineResultHeader(total=total), body=EngineResultBody()
         )
-        if len(selects) == 0:
+        if len(elements) == 0:
             # Nothing would be in body
             return result
         # extract primary data
         if query_type != EngineQueryType.COUNT:
-            self.extract_hits(source_filters, rawresult["hits"]["hits"], result.body)
+            self.extract_hits(element_filters, rawresult["hits"]["hits"], result.body)
 
         if "_scroll_id" in rawresult and result.header.total > len(
             rawresult["hits"]["hits"]
@@ -257,7 +167,7 @@ class ElasticsearchEngine(Engine):
                 if len(raw_res["hits"]["hits"]) == 0:
                     break
 
-                self.extract_hits(source_filters, raw_res["hits"]["hits"], result.body)
+                self.extract_hits(element_filters, raw_res["hits"]["hits"], result.body)
 
                 consumed += len(raw_res["hits"]["hits"])
 

--- a/src/fhirpath/engine/es/mapping.py
+++ b/src/fhirpath/engine/es/mapping.py
@@ -119,7 +119,9 @@ def create_resource_mapping(elements_paths_def, fhir_es_mappings):
 
 
 def fhir_types_mapping(
-    fhir_release: str, reference_analyzer=None, token_normalizer=None,
+    fhir_release: str,
+    reference_analyzer=None,
+    token_normalizer=None,
 ):
     Boolean = {"type": "boolean", "store": False}
     Float = {"type": "float", "store": False}

--- a/src/fhirpath/engine/es/mapping.py
+++ b/src/fhirpath/engine/es/mapping.py
@@ -119,9 +119,7 @@ def create_resource_mapping(elements_paths_def, fhir_es_mappings):
 
 
 def fhir_types_mapping(
-    fhir_release: str,
-    reference_analyzer=None,
-    token_normalizer=None,
+    fhir_release: str, reference_analyzer=None, token_normalizer=None,
 ):
     Boolean = {"type": "boolean", "store": False}
     Float = {"type": "float", "store": False}

--- a/src/fhirpath/fql/types.py
+++ b/src/fhirpath/fql/types.py
@@ -86,6 +86,7 @@ class WhereClause(FqlClause):
 class SelectClause(FqlClause):
     """ """
 
+
 class ElementClause(FqlClause):
     """ """
 

--- a/src/fhirpath/fql/types.py
+++ b/src/fhirpath/fql/types.py
@@ -86,6 +86,9 @@ class WhereClause(FqlClause):
 class SelectClause(FqlClause):
     """ """
 
+class ElementClause(FqlClause):
+    """ """
+
 
 class FromClause(FqlClause):
     """ """

--- a/src/fhirpath/query.py
+++ b/src/fhirpath/query.py
@@ -372,7 +372,7 @@ class QueryResult(ABC):
 
     def fetchall(self):
         """ """
-        result = self._engine.execute(self._query, self._unrestricted)     
+        result = self._engine.execute(self._query, self._unrestricted)
         return result.filter(self._query.get_select())
 
     def single(self):

--- a/src/fhirpath/query.py
+++ b/src/fhirpath/query.py
@@ -372,8 +372,7 @@ class QueryResult(ABC):
 
     def fetchall(self):
         """ """
-        result = self._engine.execute(self._query, self._unrestricted)
-        return result.filter(self._query.get_select())
+        return self._engine.execute(self._query, self._unrestricted)
 
     def single(self):
         """Will return the single item in the input if there is just one item.
@@ -496,7 +495,7 @@ class QueryResult(ABC):
         result = self._engine.execute(self._query, self._unrestricted)
         model_class = self._query.get_from()[0][1]
         for row in result.body:
-            if self._query.get_select()[0].star:
+            if self._query.get_element()[0].star:
                 yield model_class(**row[0])
             else:
                 yield row

--- a/src/fhirpath/search.py
+++ b/src/fhirpath/search.py
@@ -30,6 +30,7 @@ from fhirpath.enums import (
 from fhirpath.exceptions import ValidationError
 from fhirpath.fhirspec import (
     FHIRSearchSpecFactory,
+    lookup_fhir_resource_spec,
     ResourceSearchParameterDefinition,
     SearchParameter,
     search_param_prefixes,
@@ -95,8 +96,7 @@ class SearchContext(object):
         self.definitions = self.get_parameters_definition(self.engine.fhir_release)
 
     def get_parameters_definition(
-        self,
-        fhir_release: FHIR_VERSION,
+        self, fhir_release: FHIR_VERSION,
     ) -> List[ResourceSearchParameterDefinition]:
         """ """
         fhir_release = FHIR_VERSION.normalize(fhir_release)
@@ -468,6 +468,7 @@ class Search(object):
 
         builder = self.attach_where_terms(builder)
         builder = self.attach_sort_terms(builder)
+        builder = self.attach_summary_terms(builder)
         builder = self.attach_limit_terms(builder)
 
         # handle _has predicates
@@ -1556,6 +1557,75 @@ class Search(object):
             if current_page > 1:
                 offset = (current_page - 1) * self.result_params["_count"]
         return builder.limit(self.result_params["_count"], offset)
+
+    def attach_summary_terms(self, builder):
+        """ """
+        if "_summary" not in self.result_params:
+            return builder
+
+        if self.result_params["_summary"] in ["count", "false"]:
+            return builder
+
+        specs = [
+            lookup_fhir_resource_spec(r, True, FHIR_VERSION.R4)
+            for r in self.context.resource_types
+        ]
+
+        if self.result_params["_summary"] in ("data", "true"):
+
+            summary_elements = [
+                f"{r}.{attr}"
+                for r in self.context.resource_types
+                for attr in ["id", "meta"]
+            ]
+
+            def should_include(attr):
+                if self.result_params["_summary"] == "data":
+                    return (
+                        not attr.path.endswith(".text")
+                        and not attr.is_main_profile_element
+                    )
+                elif self.result_params["_summary"] == "true":
+                    return attr.is_summary
+
+            # filter all summary attributes
+            summary_attributes = [
+                attr for spec in specs for attr in spec.elements if should_include(attr)
+            ]
+
+            def get_attr_paths(attribute):
+                if attribute.path.endswith("[x]"):
+                    for prop in attribute.as_properties():
+                        return [
+                            f"{prop.path.rsplit('.', 1)[0]}.{prop.name}"
+                            for prop in attribute.as_properties()
+                        ]
+                else:
+                    return [attribute.path]
+
+            # append summary attributes' paths to summary_elements
+            summary_elements.extend(
+                [path for attr in summary_attributes for path in get_attr_paths(attr)]
+            )
+
+            return builder.element(*summary_elements)
+
+        if self.result_params["_summary"] == "text":
+            text_elements = [
+                el.path
+                for spec in specs
+                for el in spec.elements
+                if el.n_min is not None and el.n_min > 0
+            ]
+            text_elements.extend(
+                [
+                    f"{r}.{attr}"
+                    for r in self.context.resource_types
+                    for attr in ["text", "id", "meta"]
+                ]
+            )
+
+            return builder.element(*text_elements)
 
     def response(self, result, includes, as_json):
         """ """

--- a/src/fhirpath/search.py
+++ b/src/fhirpath/search.py
@@ -30,9 +30,9 @@ from fhirpath.enums import (
 from fhirpath.exceptions import ValidationError
 from fhirpath.fhirspec import (
     FHIRSearchSpecFactory,
-    lookup_fhir_resource_spec,
     ResourceSearchParameterDefinition,
     SearchParameter,
+    lookup_fhir_resource_spec,
     search_param_prefixes,
 )
 from fhirpath.fql import (

--- a/src/fhirpath/search.py
+++ b/src/fhirpath/search.py
@@ -96,7 +96,8 @@ class SearchContext(object):
         self.definitions = self.get_parameters_definition(self.engine.fhir_release)
 
     def get_parameters_definition(
-        self, fhir_release: FHIR_VERSION,
+        self,
+        fhir_release: FHIR_VERSION,
     ) -> List[ResourceSearchParameterDefinition]:
         """ """
         fhir_release = FHIR_VERSION.normalize(fhir_release)

--- a/src/fhirpath/utils.py
+++ b/src/fhirpath/utils.py
@@ -33,6 +33,7 @@ from yarl import URL
 from zope.interface import implementer
 
 from fhirpath.thirdparty import Proxy
+from fhir.resources.fhirabstractmodel import FHIRAbstractModel
 
 from .enums import FHIR_VERSION
 from .interfaces import IPathInfoContext
@@ -565,9 +566,13 @@ class BundleWrapper:
             if isinstance(resource, dict):
                 resource_id = resource["id"]
                 resource_type = resource["resourceType"]
-            else:
+            elif isinstance(resource, FHIRAbstractModel):
                 resource_id = resource.id
                 resource_type = resource.resource_type
+            else:
+                raise NotImplementedError(
+                    f"EngineRowResult must be a dict or FHIRAbstractModel, got: {row}"
+                )
             # entry = BundleEntry
             entry = dict()
             entry["fullUrl"] = "{0}/{1}".format(resource_type, resource_id)

--- a/src/fhirpath/utils.py
+++ b/src/fhirpath/utils.py
@@ -33,7 +33,6 @@ from yarl import URL
 from zope.interface import implementer
 
 from fhirpath.thirdparty import Proxy
-from fhir.resources.fhirabstractmodel import FHIRAbstractModel
 
 from .enums import FHIR_VERSION
 from .interfaces import IPathInfoContext

--- a/tests/_static/FHIR/Patient.json
+++ b/tests/_static/FHIR/Patient.json
@@ -47,6 +47,7 @@
             "value": "demo1@example.com"
         }
     ],
+    "birthDate": "1995-12-25", 
     "gender": "male",
     "resourceType": "Patient",
     "active": true,
@@ -74,5 +75,26 @@
             "value": "19c5245f-89a8-49f8-b244-666b32adb92e"
         }
     ],
-    "id": "19c5245f-89a8-49f8-b244-666b32adb92e"
+    "id": "19c5245f-89a8-49f8-b244-666b32adb92e",
+    "meta": {
+        "lastUpdated": "2020-06-22T09:29:23+00:00",
+        "profile": ["http://hl7.org/fhir/StructureDefinition/Patient"],
+        "tag": [
+            {
+                "code": "testme"
+            }
+        ]
+    },
+    "text": {
+        "status": "generated",
+        "div": "\u003cdiv xmlns\u003d\"http://www.w3.org/1999/xhtml\"\u003e\n      \n      \u003cp\u003ePatient P. van de Heuvel @ Acme Healthcare, Inc. MR \u003d 654321\u003c/p\u003e\n    \n    \u003c/div\u003e"
+    },
+    "link": [
+        {
+            "other": {
+                "reference": "Organization/f001"
+            },
+            "type": "seealso"
+        }
+    ]
 }

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -145,9 +145,8 @@ def test_result_count(es_data, engine):
     load_organizations_data(conn, 5)
     builder = Q_(resource="Organization", engine=engine)
     builder = builder.where(T_("Organization.active") == V_("true"))
-    total = builder(async_result=False).count()
-
-    assert total == 6
+    bundle = builder(async_result=False).count()
+    assert bundle.header.total == 6
 
 
 def test_result_empty(es_data, engine):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -653,18 +653,28 @@ def test_search_identifier_modifier(es_data, engine):
     # [param-ref]:identifier=[system]|[value]: the value of [code] matches an
     # reference.identifier.value, and the value of [system] matches the system
     # property of the Identifier
-    params = (("subject:identifier", "CPR|240365-0002",),)
+    params = (
+        (
+            "subject:identifier",
+            "CPR|240365-0002",
+        ),
+    )
     bundle = Search(search_context, params=params)()
     assert bundle.total == 1
 
-    params = (("subject:identifier", "CPR|123456789",),)
+    params = (
+        (
+            "subject:identifier",
+            "CPR|123456789",
+        ),
+    )
     bundle = Search(search_context, params=params)()
     assert bundle.total == 0
 
-    # TODO: not working yet, when omitting the system, the search is applied only on the value
-    # (it should also filter by empty system)
-    # [param-ref]:identifier=|[code]: the value of [code] matches a reference.identifier.value,
-    # and the Identifier has no system property
+    # TODO: not working yet, when omitting the system, the search is applied only
+    # on the value (it should also filter by empty system)
+    # [param-ref]:identifier=|[code]: the value of [code] matches a
+    # reference.identifier.value, and the Identifier has no system property
     params = (("subject:identifier", "|240365-0002"),)
     bundle = Search(search_context, params=params)()
     assert bundle.total == 1
@@ -673,9 +683,14 @@ def test_search_identifier_modifier(es_data, engine):
     bundle = Search(search_context, params=params)()
     assert bundle.total == 0
 
-    # [param-ref]:identifier=[system]|: any element where the value of [system] matches the
-    # system property of the Identifier
-    params = (("subject:identifier", "CPR|",),)
+    # [param-ref]:identifier=[system]|: any element where the value of [system] matches
+    # the system property of the Identifier
+    params = (
+        (
+            "subject:identifier",
+            "CPR|",
+        ),
+    )
     bundle = Search(search_context, params=params)()
     assert bundle.total == 1
 
@@ -706,7 +721,10 @@ def test_search_negative_address(es_data, engine):
     bundle = fhir_search()
     assert bundle.total == 0
     params = (
-        ("_profile:not", "urn:oid:002.160,urn:oid:002.260,http://hl7.org/fhir/Other",),
+        (
+            "_profile:not",
+            "urn:oid:002.160,urn:oid:002.260,http://hl7.org/fhir/Other",
+        ),
     )
     fhir_search = Search(search_context, params=params)
     bundle = fhir_search()
@@ -1274,8 +1292,9 @@ def test_searchparam_ignored_pretty_format(es_data, engine):
 
 def test_searchparam_summary_true(es_data, engine):
     """Handle _summary=true
-    Return a limited subset of elements from the resource. This subset SHOULD consist solely of all
-    supported elements that are marked as "summary" in the base definition of the resource(s)
+    Return a limited subset of elements from the resource. This subset SHOULD consist
+    solely of all supported elements that are marked as "summary" in the base definition
+    of the resource(s)
     """
     search_context = SearchContext(engine, "Patient")
     result = Search(search_context, params=(("_summary", "true"),))()
@@ -1305,8 +1324,8 @@ def test_searchparam_summary_false(es_data, engine):
 
 def test_searchparam_summary_text(es_data, engine):
     """Handle _summary=text
-    Return only the "text" element, the 'id' element, the 'meta' element, and only top-level
-    mandatory elements
+    Return only the "text" element, the 'id' element, the 'meta' element,
+    and only top-level mandatory elements
     """
     search_context = SearchContext(engine, "Patient")
     result = Search(search_context, params=(("_summary", "text"),))()
@@ -1333,7 +1352,8 @@ def test_searchparam_summary_data(es_data, engine):
 
 def test_searchparam_summary_count(es_data, engine):
     """Handle _summary=count
-    Search only: just return a count of the matching resources, without returning the actual matches
+    Search only: just return a count of the matching resources, without returning the
+    actual matches
     """
     search_context = SearchContext(engine, "Patient")
     result = Search(search_context, params=(("_summary", "count"),))()


### PR DESCRIPTION
- We needed a way to differentiate the way we handle `selects` (in fhirpath expressions) and `_elements` that specify which fhir attribute to include in the search result (in ES, this is handled via the projection query). Therefore we added a new `
element` attribute in the Query class and kept the `select`attribute to handle fhirpath expressions.

- Implemented summaries (_summary=text, _summary=true, _summary=data) and added tests.

- Slightly changed the way QueryResult.count() works, now it returns a Bundle (not just an integer) but with an empty set of items (only the header with the number of results is filled). You can still use the old behaviour of .count() with `len(QueryResult)` which returns the number of results as an integer