### PR TITLE
Fixes an issue in ES Query term creation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ Improvement
 
 
 Fixes
+- fixes ``ElasticSearchDialect.create_term`` [Kartik Sayani]
 
 - fixes ``EngineResult.extract_references``. [Jason Paumier]
 

--- a/src/fhirpath/dialects/elasticsearch.py
+++ b/src/fhirpath/dialects/elasticsearch.py
@@ -111,9 +111,11 @@ class ElasticSearchDialect(DialectBase):
             # TODO is there a better way to search on all resource types?
             # TODO does it work if both all_resources and multiple_ are True?
             q = {"multi_match": {"query": value, "fields": [path]}}
-        elif match_type == TermMatchType.EXACT:
+        elif match_type == TermMatchType.EXACT and not multiple_:
             q = {"term": {f"{path}.raw": value}}
-        elif multiple_:
+        elif match_type == TermMatchType.EXACT and multiple_:
+            q = {"terms": {f"{path}.raw": value}}
+        elif match_type != TermMatchType.EXACT and multiple_:
             q = {"terms": {path: value}}
         else:
             q = {"match": {path: value}}

--- a/tests/dialects/test_elasticsearch.py
+++ b/tests/dialects/test_elasticsearch.py
@@ -60,6 +60,7 @@ async def test_dialect_generated_raw_query(es_data, engine):
         ("name", "Saint"),
         ("email", "demo1@example.com"),
         ("phone", "2562000002"),
+        ("given:exact", "Eelector"),
     )
     search_tool = Search(context=search_context, params=params)
     result_query = search_tool.build()


### PR DESCRIPTION
Fixes a small bug that surfaces when trying to search with `:exact` modifier on when `multiple = True` in creating ES query term.

Steps to reproduce:
```
search_context = SearchContext(engine, "Patient")
params = (("given:exact", "Eelector"),)
search_tool = Search(search_context, params=params)
bundle = search_tool(as_json=True)
```